### PR TITLE
sampleRateの修正

### DIFF
--- a/functions/services/googleService.js
+++ b/functions/services/googleService.js
@@ -37,7 +37,7 @@ class GoogleService {
     // https://cloud.google.com/speech-to-text/docs/reference/rest/v1p1beta1/RecognitionConfig
     const audioConfig = {
       encoding: "WEBM_OPUS",
-      sampleRateHertz: 8000,
+      sampleRateHertz: 48000,
       languageCode: language,
       enableSpeakerDiarization: true,
       minSpeakerCount: 2,


### PR DESCRIPTION
{"status":"failed","error":"3 INVALID_ARGUMENT: Sync input too long. For audio longer than 1 min use LongRunningRecognize with a 'uri' parameter.","details":"音声の文字起こし中にエラーが発生しました。音声ファイルの形式やサイズを確認してください。"}
  
のエラーへの対応